### PR TITLE
Add cleaning, docking and status commands

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,12 +75,18 @@ Create `.env` file with your Roborock credentials and dance defaults.
 # Using the installed command (selects the first S4 Max / `roborock.vacuum.a19`):
 uv run vacuum-ballet devices
 uv run vacuum-ballet beep
+uv run vacuum-ballet status
+uv run vacuum-ballet clean
+uv run vacuum-ballet dock
 uv run vacuum-ballet goto 32500 27500
 uv run vacuum-ballet dance figure8 100 600
 
 # Or run directly with Python:
 uv run python src/main.py devices
 uv run python src/main.py beep
+uv run python src/main.py status
+uv run python src/main.py clean
+uv run python src/main.py dock
 uv run python src/main.py goto 32500 27500
 uv run python src/main.py dance figure8 100 600
 ```
@@ -111,7 +117,9 @@ uv run pytest
 2. Create `src/main.py` with all functionality.
 3. Verify `uv run vacuum-ballet devices` lists a device.
 4. Verify `uv run vacuum-ballet beep`.
-5. Verify `uv run vacuum-ballet goto` small move.
-6. Verify `uv run vacuum-ballet dance` with small radius.
-7. Run `uv run pytest`.
-8. Keep docs in sync.
+5. Verify `uv run vacuum-ballet status`.
+6. Verify `uv run vacuum-ballet clean` then `uv run vacuum-ballet dock`.
+7. Verify `uv run vacuum-ballet goto` small move.
+8. Verify `uv run vacuum-ballet dance` with small radius.
+9. Run `uv run pytest`.
+10. Keep docs in sync.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Learn-by-doing control of a Roborock **S4 Max** using Python. This repo stays on the *easy, no-disassembly* path:
 - Uses the `python-roborock` SDK with your Roborock app credentials.
 - Sends simple **go‑to** waypoints to choreograph circles, squares, figure‑eights, and Lissajous patterns.
-- Includes a tiny CLI: `vacuum-ballet`.
+- Includes a tiny CLI: `vacuum-ballet` for beeps, status, cleaning and docking.
 
 > Safety first: test in a clear 2×2 m area, start with small radii, and keep people/pets away.
 
@@ -24,16 +24,22 @@ uv sync
 # 3) See devices on your account (S4 Max is model roborock.vacuum.a19)
 uv run vacuum-ballet devices
 
-# 4) Safe beep test
-uv run vacuum-ballet beep
+# 4) Check status and battery
+uv run vacuum-ballet status
 
-# 5) Tiny motion (adjust x/y to a near point on your map, units: millimetres)
+# 5) Start cleaning
+uv run vacuum-ballet clean
+
+# 6) Return to dock
+uv run vacuum-ballet dock
+
+# 7) Tiny motion (adjust x/y to a near point on your map, units: millimetres)
 uv run vacuum-ballet goto 32500 27500
 
-# 6) Dance! (pattern radius_mm beat_ms)
+# 8) Dance! (pattern radius_mm beat_ms)
 uv run vacuum-ballet dance figure8 100 600
 
-# 7) Run tests
+# 9) Run tests
 uv run pytest
 ```
 
@@ -55,6 +61,7 @@ vacuum-ballet/
     main.py          # All the code in one simple file!
   tests/
     test_main.py
+    test_commands.py
 ```
 
 See **BUILDING.md** for deeper instructions and agent-friendly tasks.

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Tests for basic command functions."""
+
+import asyncio
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, patch
+
+# Allow importing from the src directory
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from main import clean, dock, status as status_cmd  # type: ignore
+from roborock.roborock_typing import RoborockCommand
+from roborock.containers import Status
+
+
+class TestCommands(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = AsyncMock()
+        self.client.send_command = AsyncMock()
+        self.client.async_disconnect = AsyncMock()
+        self.client.get_status = AsyncMock()
+
+    def test_clean_sends_start(self) -> None:
+        with patch('main._client', AsyncMock(return_value=self.client)):
+            asyncio.run(clean())
+            self.client.send_command.assert_called_with(RoborockCommand.APP_START)
+            self.client.async_disconnect.assert_awaited()
+
+    def test_dock_sends_charge(self) -> None:
+        with patch('main._client', AsyncMock(return_value=self.client)):
+            asyncio.run(dock())
+            self.client.send_command.assert_called_with(RoborockCommand.APP_CHARGE)
+            self.client.async_disconnect.assert_awaited()
+
+    def test_clean_disconnects_on_error(self) -> None:
+        self.client.send_command.side_effect = RuntimeError
+        with patch('main._client', AsyncMock(return_value=self.client)):
+            with self.assertRaises(RuntimeError):
+                asyncio.run(clean())
+        self.client.async_disconnect.assert_awaited()
+
+    def test_status_prints(self) -> None:
+        st = Status(battery=50)
+        self.client.get_status.return_value = st
+        with patch('main._client', AsyncMock(return_value=self.client)):
+            with patch('builtins.print') as mock_print:
+                asyncio.run(status_cmd())
+            mock_print.assert_called_with("State: unknown, Battery: 50%")
+            self.client.async_disconnect.assert_awaited()
+
+
+if __name__ == '__main__':  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- Support clean, dock and status operations in CLI using python-roborock commands
- Close Roborock MQTT client even when commands fail
- Document new commands and update build instructions
- Cover new functions with unit tests

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7a865ac588325b6eea36ba4605bdd